### PR TITLE
chore: crowdin.yml make Fastlane metadata translatable and use %android_code%

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,8 +1,7 @@
 files:
   - source: /app/src/main/res/values/strings.xml
-    translation: /app/src/main/res/values-%two_letters_code%/%original_file_name%
-    languages_mapping:
-      two_letters_code:
-        id: in
+    translation: /app/src/main/res/values-%android_code%/%original_file_name%
+    translate_content: 0
     translate_attributes: 0
-    update_option: update_as_unapproved
+  - source: /fastlane/metadata/android/en-US/*.txt
+    translation: /fastlane/metadata/android/%locale%/%original_file_name%


### PR DESCRIPTION
Use %android_code% that should also should use code `values-in-rID` for Indonesian so it shouldn't need for the manual mapping of the `id: in`.
The `%locale%` will always use a language code with a country i.e. `id_ID` for Indonesian. So while the `values` will use the `in` the metadata will will use `id`. It should be ok for both F-Droid and PlayStore.
 
Replaces: #6
