### PR TITLE
fix(shownotes): use MIXED_CONTENT_COMPATIBILITY_MODE in ShownotesWebView

### DIFF
--- a/app/src/main/kotlin/ac/mdiq/podcini/ui/utils/ShownotesWebView.kt
+++ b/app/src/main/kotlin/ac/mdiq/podcini/ui/utils/ShownotesWebView.kt
@@ -52,7 +52,7 @@ class ShownotesWebView : WebView, View.OnLongClickListener {
 //        if (!NetworkUtils.networkAvailable()) getSettings().cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
 //        settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
 
-        settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+        settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
         settings.useWideViewPort = false
         settings.loadWithOverviewMode = true
         setOnLongClickListener(this)


### PR DESCRIPTION
Closes #59.

`ShownotesWebView.setup()` sets:

```kotlin
settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
```

The same WebView is fed via `loadDataWithBaseURL("https://127.0.0.1", ...)` in `Episodes.kt`, so it is treated as an https origin. With `ALWAYS_ALLOW` any cleartext `http://` sub-resource referenced from feed-supplied show-notes HTML (images, scripts, stylesheets) loads anyway, which gives the feed author free reign to drop trackers or fetch attacker-controlled `http://` resources whose hosts the user did not pick.

### Change

Switch the one constant to `MIXED_CONTENT_COMPATIBILITY_MODE`:

```kotlin
settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
```

This matches how Chrome handles mixed content on desktop: active mixed content (script, css, iframe) is blocked, passive content (`<img>`, `<audio>`, `<video>` poster) still renders. For normal podcast show-notes there is no visible change.

If a specific feed exercises an active cleartext sub-resource that COMPATIBILITY blocks, the cleaner fix is to rewrite the URL inside `ShownotesCleaner` rather than weaken the WebView for every feed.