### PR TITLE
Hand off show-notes WebView link taps to the system browser

### DIFF
--- a/app/src/main/kotlin/ac/mdiq/podcini/ui/compose/EpisodeScreen.kt
+++ b/app/src/main/kotlin/ac/mdiq/podcini/ui/compose/EpisodeScreen.kt
@@ -42,6 +42,7 @@ import ac.mdiq.podcini.utils.formatDateTimeFlex
 import ac.mdiq.podcini.utils.formatShortFileSize
 import ac.mdiq.podcini.utils.openInBrowser
 import android.speech.tts.TextToSpeech
+import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -490,6 +491,11 @@ fun EpisodeWebView(episode: Episode) {
                             settings.domStorageEnabled = true
                             settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                             webViewClient = object : WebViewClient() {
+                                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                                    val url = request?.url?.toString() ?: return false
+                                    openInBrowser(url)
+                                    return true
+                                }
                                 override fun onPageFinished(view: WebView?, url: String?) {
                                     val isEmpty = view?.title.isNullOrEmpty() && view?.contentDescription.isNullOrEmpty()
                                     if (isEmpty) Logd(TAG, "content is empty")


### PR DESCRIPTION
Closes #61.

The show-notes `WebView` in `EpisodeScreen.kt` only overrides `onPageFinished`, so any tapped link inside the notes navigates the WebView itself. The show-notes page then disappears, replaced with the linked target, and there is no per-WebView UI to navigate back. `mailto:` and `tel:` links fail for the same reason.

This adds a `shouldOverrideUrlLoading` override on the readMode WebView that hands every tapped URL to the existing `openInBrowser(url)` helper, which already wraps `startActivity` with a try/catch for `ActivityNotFoundException`.

```diff
+import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@
                             settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                             webViewClient = object : WebViewClient() {
+                                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                                    val url = request?.url?.toString() ?: return false
+                                    openInBrowser(url)
+                                    return true
+                                }
                                 override fun onPageFinished(view: WebView?, url: String?) {
```

`openInBrowser` is the existing helper in `IntentUtils.kt` already imported in this file. The non-readMode WebView (the in-app browser for `episode.link`) is untouched - users browsing a podcast website with in-page navigation get the same behavior as before.